### PR TITLE
feat: Add private repo tooltip to project pages

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1048,8 +1048,8 @@ packages:
     engines: {node: '>=0.4.0'}
     hasBin: true
 
-  agent-base@7.1.3:
-    resolution: {integrity: sha512-jRR5wdylq8CkOe6hei19GGZnxM6rBGwFl3Bg0YItGDimvjGtAvdZk4Pu6Cl4u4Igsws4a1fd1Vq3ezrhn4KmFw==}
+  agent-base@7.1.4:
+    resolution: {integrity: sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==}
     engines: {node: '>= 14'}
 
   ajv@6.12.6:
@@ -1342,8 +1342,8 @@ packages:
   eastasianwidth@0.2.0:
     resolution: {integrity: sha512-I88TYZWc9XiYHRQ4/3c5rjjfgkjhLyW2luGIheGERbNQ6OY7yTybanSpDXZa8y7VUP9YmDcYa+eyq4ca7iLqWA==}
 
-  electron-to-chromium@1.5.179:
-    resolution: {integrity: sha512-UWKi/EbBopgfFsc5k61wFpV7WrnnSlSzW/e2XcBmS6qKYTivZlLtoll5/rdqRTxGglGHkmkW0j0pFNJG10EUIQ==}
+  electron-to-chromium@1.5.180:
+    resolution: {integrity: sha512-ED+GEyEh3kYMwt2faNmgMB0b8O5qtATGgR4RmRsIp4T6p7B8vdMbIedYndnvZfsaXvSzegtpfqRMDNCjjiSduA==}
 
   emmet@2.4.11:
     resolution: {integrity: sha512-23QPJB3moh/U9sT4rQzGgeyyGIrcM+GH5uVYg2C6wZIxAIJq7Ng3QLT79tl8FUwDXhyq9SusfknOrofAKqvgyQ==}
@@ -2698,8 +2698,8 @@ packages:
       typescript: ^4.9.4 || ^5.0.2
       zod: ^3
 
-  zod@3.25.75:
-    resolution: {integrity: sha512-OhpzAmVzabPOL6C3A3gpAifqr9MqihV/Msx3gor2b2kviCgcb+HM9SEOpMWwwNp9MRunWnhtAKUoo0AHhjyPPg==}
+  zod@3.25.76:
+    resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -2831,7 +2831,7 @@ snapshots:
     dependencies:
       sitemap: 8.0.0
       stream-replace-string: 2.0.0
-      zod: 3.25.75
+      zod: 3.25.76
 
   '@astrojs/telemetry@3.3.0':
     dependencies:
@@ -3694,7 +3694,7 @@ snapshots:
 
   acorn@8.15.0: {}
 
-  agent-base@7.1.3: {}
+  agent-base@7.1.4: {}
 
   ajv@6.12.6:
     dependencies:
@@ -3743,7 +3743,7 @@ snapshots:
   astro-robots-txt@1.0.0:
     dependencies:
       valid-filename: 4.0.0
-      zod: 3.25.75
+      zod: 3.25.76
 
   astro-seo@0.8.4(typescript@5.8.3):
     dependencies:
@@ -3813,9 +3813,9 @@ snapshots:
       xxhash-wasm: 1.1.0
       yargs-parser: 21.1.1
       yocto-spinner: 0.2.3
-      zod: 3.25.75
-      zod-to-json-schema: 3.24.6(zod@3.25.75)
-      zod-to-ts: 1.2.0(typescript@5.8.3)(zod@3.25.75)
+      zod: 3.25.76
+      zod-to-json-schema: 3.24.6(zod@3.25.76)
+      zod-to-ts: 1.2.0(typescript@5.8.3)(zod@3.25.76)
     optionalDependencies:
       sharp: 0.33.5
     transitivePeerDependencies:
@@ -3903,7 +3903,7 @@ snapshots:
   browserslist@4.25.1:
     dependencies:
       caniuse-lite: 1.0.30001727
-      electron-to-chromium: 1.5.179
+      electron-to-chromium: 1.5.180
       node-releases: 2.0.19
       update-browserslist-db: 1.1.3(browserslist@4.25.1)
 
@@ -4050,7 +4050,7 @@ snapshots:
 
   eastasianwidth@0.2.0: {}
 
-  electron-to-chromium@1.5.179: {}
+  electron-to-chromium@1.5.180: {}
 
   emmet@2.4.11:
     dependencies:
@@ -4382,7 +4382,7 @@ snapshots:
 
   https-proxy-agent@7.0.6:
     dependencies:
-      agent-base: 7.1.3
+      agent-base: 7.1.4
       debug: 4.4.1
     transitivePeerDependencies:
       - supports-color
@@ -5833,15 +5833,15 @@ snapshots:
 
   yoctocolors@2.1.1: {}
 
-  zod-to-json-schema@3.24.6(zod@3.25.75):
+  zod-to-json-schema@3.24.6(zod@3.25.76):
     dependencies:
-      zod: 3.25.75
+      zod: 3.25.76
 
-  zod-to-ts@1.2.0(typescript@5.8.3)(zod@3.25.75):
+  zod-to-ts@1.2.0(typescript@5.8.3)(zod@3.25.76):
     dependencies:
       typescript: 5.8.3
-      zod: 3.25.75
+      zod: 3.25.76
 
-  zod@3.25.75: {}
+  zod@3.25.76: {}
 
   zwitch@2.0.4: {}

--- a/src/data/web-projects/almaissues.mdx
+++ b/src/data/web-projects/almaissues.mdx
@@ -10,7 +10,7 @@ alt_1: "Alma Issues homepage"
 image_2: "../../assets/projects/almaissues/products.png"
 alt_2: "Products page"
 github: "https://github.com/albertevieites/almaissues"
-deploy: "https://almaissues.vercel.app/"
+deploy: "https://almaissues.com/"
 features:
   - title: "Modern E-commerce Platform"
     description: "Complete online shopping experience with product catalogs, shopping cart, and secure checkout process"

--- a/src/pages/projects/[id].astro
+++ b/src/pages/projects/[id].astro
@@ -34,7 +34,7 @@ const project = await getEntry(collection, id);
 
 // ✨ AÑADIDO: Comprobación para manejar el caso en que el proyecto no exista
 if (!project) {
-  return Astro.redirect("/404");
+	return Astro.redirect("/404");
 }
 
 const { data: projectData } = project;
@@ -54,7 +54,18 @@ const { data: projectData } = project;
 			</div>
 			<div class="project__content--item project__content--description">
 				<div class="project__content--buttons">
-					<a href={projectData.github}>Github</a>
+					{
+						projectData.isPrivate ? (
+							<div class="card__links--private">
+								Github
+								<span class="tooltiptext">
+									This repository is private due to a client agreement.
+								</span>
+							</div>
+						) : (
+							<a href={projectData.github}>Github</a>
+						)
+					}
 					{projectData.deploy && <a href={projectData.deploy}>Deployment</a>}
 				</div>
 				<p>{projectData.overview}</p>
@@ -115,7 +126,18 @@ const { data: projectData } = project;
 		</div>
 
 		<div class="project__cta">
-			<a href={projectData.github}>Contribute to project</a>
+			{
+				projectData.isPrivate ? (
+					<div class="card__links--private">
+						Contribute to project
+						<span class="tooltiptext">
+							This repository is private due to a client agreement.
+						</span>
+					</div>
+				) : (
+					<a href={projectData.github}>Contribute to project</a>
+				)
+			}
 			<a href="/work" class="btn btn-secondary">Back to Projects</a>
 		</div>
 

--- a/src/styles/abstracts/_mixins.scss
+++ b/src/styles/abstracts/_mixins.scss
@@ -2,6 +2,7 @@
 @use "sass:meta";
 @use "sass:math";
 @use "breakpoints" as bp;
+@use "colors";
 
 // --- Mixin para Media Queries (min-width) ---
 // Aplica estilos DESDE un breakpoint específico HACIA ARRIBA.
@@ -168,5 +169,27 @@
 		&:hover {
 			font-style: italic;
 		}
+	}
+}
+
+// --- BUTTONS ---
+@mixin button-style($color) {
+	padding: 0.5rem 1.3rem;
+	border: 1px solid $color;
+	border-radius: 2rem;
+	position: relative; // Needed for tooltip positioning
+
+	// Hover animations
+	background-color: transparent;
+	background-image: linear-gradient(to right, $color 0%, $color 100%);
+	background-size: 0% 100%;
+	background-repeat: no-repeat;
+	transition: 0.3s ease-out;
+
+	&:hover {
+		background-color: $color;
+		background-size: 100% 100%;
+
+		color: colors.$clr-bk;
 	}
 }

--- a/src/styles/components/_card.scss
+++ b/src/styles/components/_card.scss
@@ -1,5 +1,45 @@
 @use "../abstracts" as abstracts;
 
+.card__links--private {
+	position: relative;
+	cursor: not-allowed;
+
+	.tooltiptext {
+		visibility: hidden;
+		width: 200px;
+		background-color: #555;
+		color: #fff;
+		text-align: center;
+		border-radius: 6px;
+		padding: 8px 5px;
+		position: absolute;
+		z-index: 1;
+		bottom: 125%;
+		left: 50%;
+		margin-left: -100px;
+		opacity: 0;
+		transition: opacity 0.3s;
+		font-size: 12px;
+		transform: skew(0deg) !important;
+
+		&::after {
+			content: "";
+			position: absolute;
+			top: 100%;
+			left: 50%;
+			margin-left: -5px;
+			border-width: 5px;
+			border-style: solid;
+			border-color: #555 transparent transparent transparent;
+		}
+	}
+
+	&:hover .tooltiptext {
+		visibility: visible;
+		opacity: 1;
+	}
+}
+
 .card {
 	display: flex;
 	justify-content: space-between;
@@ -86,50 +126,6 @@
 			justify-content: center;
 			width: 100%;
 			height: 100%;
-		}
-
-		&--private {
-			position: relative;
-			cursor: not-allowed;
-
-			.tooltiptext {
-				visibility: hidden;
-				width: 200px;
-				background-color: #555;
-				color: #fff;
-				text-align: center;
-				border-radius: 6px;
-				padding: 8px 5px;
-				position: absolute;
-				z-index: 1;
-				bottom: 125%;
-				left: 50%;
-				margin-left: -100px;
-				opacity: 0;
-				transition: opacity 0.3s;
-				font-size: 12px;
-				transform: skew(0deg) !important;
-
-				&::after {
-					content: "";
-					position: absolute;
-					top: 100%;
-					left: 50%;
-					margin-left: -5px;
-					border-width: 5px;
-					border-style: solid;
-					border-color: #555 transparent transparent transparent;
-				}
-			}
-
-			&:hover .tooltiptext {
-				visibility: visible;
-				opacity: 1;
-			}
-
-			&:hover span:not(.tooltiptext) {
-				transform: skewX(-12deg);
-			}
 		}
 	}
 }

--- a/src/styles/components/_project.scss
+++ b/src/styles/components/_project.scss
@@ -49,27 +49,18 @@
 
 			margin-bottom: 5rem;
 
-			a {
-				padding: 0.5rem 1.3rem;
-				border: 1px solid $clr-warm-text;
-				border-radius: 2rem;
+			a,
+			div.card__links--private {
+				@include button-style($clr-warm-text);
+			}
 
-				// Hover animations
-				background-color: transparent;
-				background-image: linear-gradient(
-					to right,
-					$clr-warm-text 0%,
-					$clr-warm-text 100%
-				);
-				background-size: 0% 100%;
-				background-repeat: no-repeat;
-				transition: 0.3s ease-out;
+			div.card__links--private {
+				cursor: not-allowed;
 
 				&:hover {
-					background-color: $clr-warm-text;
-					background-size: 100% 100%;
-
-					color: $clr-bk;
+					background-color: transparent;
+					background-size: 0% 100%;
+					color: $clr-warm-text;
 				}
 			}
 		}
@@ -130,27 +121,18 @@
 
 		margin-bottom: 7rem;
 
-		a {
-			padding: 0.5rem 1.3rem;
-			border: 1px solid $clr-white;
-			border-radius: 2rem;
+		a,
+		div.card__links--private {
+			@include button-style($clr-white);
+		}
 
-			// Hover animations
-			background-color: transparent;
-			background-image: linear-gradient(
-				to right,
-				$clr-white 0%,
-				$clr-white 100%
-			);
-			background-size: 0% 100%;
-			background-repeat: no-repeat;
-			transition: 0.3s ease-out;
+		div.card__links--private {
+			cursor: not-allowed;
 
 			&:hover {
-				background-color: $clr-white;
-				background-size: 100% 100%;
-
-				color: $clr-bk;
+				background-color: transparent;
+				background-size: 0% 100%;
+				color: $clr-white;
 			}
 		}
 	}


### PR DESCRIPTION
- Implements a tooltip for GitHub buttons on project detail pages when the repository is private.

- Refactors project page button styles using a shared Sass mixin to reduce code duplication.

- Centralizes the button-style mixin into _mixins.scss for better organization.

- Fixes a Sass compilation error by correctly importing color variables.

- Corrects a styling issue where private repository buttons appeared larger than standard buttons.